### PR TITLE
Fix table class to latest alpine website html dom

### DIFF
--- a/main.go
+++ b/main.go
@@ -132,7 +132,7 @@ func usageAndExit(message string, exitCode int) {
 
 func getFilesInfo(d *goquery.Document) []fileInfo {
 	files := []fileInfo{}
-	d.Find(".table tr:not(:first-child)").Each(func(j int, l *goquery.Selection) {
+	d.Find(".pure-table tr:not(:first-child)").Each(func(j int, l *goquery.Selection) {
 		f := fileInfo{}
 		rows := l.Find("td")
 		rows.Each(func(i int, s *goquery.Selection) {

--- a/main_test.go
+++ b/main_test.go
@@ -36,7 +36,7 @@ func TestGetFileAndPath(t *testing.T) {
 
 func TestParseHTML(t *testing.T) {
 	searchResults := `
-<table class="table table-striped table-bordered table-condensed" data-toggle="table">
+<table class="pure-table table-striped table-bordered table-condensed" data-toggle="table">
     <tbody>
 	<tr>
 	    <th>File</th>


### PR DESCRIPTION
Fix table class to latest alpine website html dom.

The Alpine Linux package page has been changed `table` class name to `pure-table` instead of `table`.

```html
<table class="pure-table pure-table-striped">
.
.
.
</table>
```